### PR TITLE
Add support for constant_pad_nd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+.cache/
 .vscode
 .env
 *.code-workspace

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -602,7 +602,7 @@ class ContiguousModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ContiguousModule())
 def ContiguousModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 1))
-    
+
 class TensorToInt(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -699,7 +699,7 @@ class AddCMulModule(torch.nn.Module):
 
     @export
     @annotate_args([
-        None,   
+        None,
         ([-1, -1], torch.float32, True),
         ([-1, -1], torch.float32, True),
         ([-1, -1], torch.float32, True),
@@ -718,7 +718,7 @@ class AddCDivModule(torch.nn.Module):
 
     @export
     @annotate_args([
-        None,   
+        None,
         ([-1, -1], torch.float32, True),
         ([-1, -1], torch.float32, True),
         ([-1, -1], torch.float32, True),
@@ -739,7 +739,7 @@ class tensorIntModule(torch.nn.Module):
 
     @export
     @annotate_args([
-        None,   
+        None,
     ])
 
     def forward(self):
@@ -756,7 +756,7 @@ class tensorFloatModule(torch.nn.Module):
 
     @export
     @annotate_args([
-        None,   
+        None,
     ])
 
     def forward(self):
@@ -962,4 +962,39 @@ class TModuleRank0(torch.nn.Module):
 @register_test_case(module_factory=lambda: TModuleRank0())
 def TModuleRank0_basic(module, tu: TestUtils):
     module.forward(torch.tensor(7, dtype=torch.float32))
+
+class TensorLiteralModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.t = torch.randint(-5, 5, (2, 3))
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.add(self.t, self.t)
+
+@register_test_case(module_factory=lambda: TensorLiteralModule())
+def TensorLiteralModule_basic(module, tu: TestUtils):
+    module.forward()
+
+
+class TensorOpaqueLiteralModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        torch.manual_seed(0)
+        self.t = torch.randint(-5, 5, (256, 1024))
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        return torch.add(self.t, self.t)
+
+@register_test_case(module_factory=lambda: TensorOpaqueLiteralModule())
+def TensorOpaqueLiteralModule_basic(module, tu: TestUtils):
+    module.forward()
 

--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -284,6 +284,47 @@ def MaxPool2dModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(1, 1, 20, 20) - 0.5)
 
 
+class ConstantPad2dStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pad2d = torch.nn.ConstantPad2d((0, 1, 2, 3), -float('inf'))
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1, 20, 20], torch.float32, True),
+    ])
+    def forward(self, x):
+        return self.pad2d(x)
+
+# ==============================================================================
+
+
+@register_test_case(module_factory=lambda: ConstantPad2dStaticModule())
+def ConstantPad2dStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 20, 20) - 0.5)
+
+
+class ConstantPadNdStaticModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1, 1, 20, 20, 4, 4], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.ops.aten.constant_pad_nd(x, (0, 1), -float('inf'))
+
+# ==============================================================================
+
+
+@register_test_case(module_factory=lambda: ConstantPadNdStaticModule())
+def ConstantPadNdStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(1, 1, 20, 20, 4, 4) - 0.5)
+
+
 class TransposeIntModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/e2e_testing/torchscript/elementwise.py
+++ b/e2e_testing/torchscript/elementwise.py
@@ -62,6 +62,28 @@ def ElementwiseBinaryModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class ElementwiseBinaryStaticShapeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([5, 4, 3, 3, 1], torch.float32, True),
+        ([4, 3, 1, 2], torch.float32, True),
+    ])
+    def forward(self, a, b):
+        return a * b
+
+@register_test_case(
+    module_factory=lambda: ElementwiseBinaryStaticShapeModule())
+def ElementwiseBinaryStaticShapeModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(5, 4, 3, 3, 1), tu.rand(4, 3, 1, 2))
+
+
+# ==============================================================================
+
+
 class ElementwiseTernaryModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -171,8 +193,7 @@ class ElementwiseUnsqueezeNegDimsModule(torch.nn.Module):
         return torch.unsqueeze(a, -3)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseUnsqueezeNegDimsModule())
+@register_test_case(module_factory=lambda: ElementwiseUnsqueezeNegDimsModule())
 def ElementwiseUnsqueezeNegDimsModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 3))
 
@@ -255,7 +276,7 @@ class ElementwiseGeluModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGeluModule())
 def ElementwiseGeluModule_basic(module, tu: TestUtils):
-    module.forward(2*tu.rand(5, 3) - 0.5)
+    module.forward(2 * tu.rand(5, 3) - 0.5)
 
 
 # ==============================================================================
@@ -359,7 +380,7 @@ class ElementwiseGtIntScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGtIntScalarModule())
 def ElementwiseGtIntScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)))
+    module.forward(torch.randint(-10, 15, (3, 4)))
 
 
 class ElementwiseGtMixed2ScalarModule(torch.nn.Module):
@@ -377,7 +398,7 @@ class ElementwiseGtMixed2ScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGtMixed2ScalarModule())
 def ElementwiseGtMixed2ScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)).to(torch.int32))
+    module.forward(torch.randint(-10, 15, (3, 4)).to(torch.int32))
 
 
 class ElementwiseGtFloatTensorModule(torch.nn.Module):
@@ -415,9 +436,11 @@ class ElementwiseGtIntTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseGtIntTensorModule())
 def ElementwiseGtIntTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5,)))
+    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5, )))
+
 
 # ==============================================================================
+
 
 class ElementwiseLtFloatScalarModule(torch.nn.Module):
     def __init__(self):
@@ -452,7 +475,7 @@ class ElementwiseLtIntScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseLtIntScalarModule())
 def ElementwiseLtIntScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)))
+    module.forward(torch.randint(-10, 15, (3, 4)))
 
 
 class ElementwiseLtDiffWidthScalarModule(torch.nn.Module):
@@ -468,9 +491,10 @@ class ElementwiseLtDiffWidthScalarModule(torch.nn.Module):
         return torch.lt(x, 2)
 
 
-@register_test_case(module_factory=lambda: ElementwiseLtDiffWidthScalarModule())
+@register_test_case(
+    module_factory=lambda: ElementwiseLtDiffWidthScalarModule())
 def ElementwiseLtDiffWidthScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 15, (3,4)).to(torch.int32))
+    module.forward(torch.randint(-10, 15, (3, 4)).to(torch.int32))
 
 
 class ElementwiseLtFloatTensorModule(torch.nn.Module):
@@ -508,9 +532,11 @@ class ElementwiseLtIntTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseLtIntTensorModule())
 def ElementwiseLtIntTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5,)))
+    module.forward(torch.randint(10, (3, 5)), torch.randint(10, (5, )))
+
 
 # ==============================================================================
+
 
 class ElementwiseEqFloatScalarModule(torch.nn.Module):
     def __init__(self):
@@ -527,8 +553,8 @@ class ElementwiseEqFloatScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqFloatScalarModule())
 def ElementwiseEqFloatScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]])
-                   .to(torch.float32))
+    module.forward(
+        torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]]).to(torch.float32))
 
 
 class ElementwiseEqIntScalarModule(torch.nn.Module):
@@ -546,7 +572,7 @@ class ElementwiseEqIntScalarModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqIntScalarModule())
 def ElementwiseEqIntScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(2, 4, (5,8)))
+    module.forward(torch.randint(2, 4, (5, 8)))
 
 
 class ElementwiseEqDiffWidthScalarModule(torch.nn.Module):
@@ -562,9 +588,10 @@ class ElementwiseEqDiffWidthScalarModule(torch.nn.Module):
         return torch.eq(x, 2)
 
 
-@register_test_case(module_factory=lambda: ElementwiseEqDiffWidthScalarModule())
+@register_test_case(
+    module_factory=lambda: ElementwiseEqDiffWidthScalarModule())
 def ElementwiseEqDiffWidthScalarModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(2, 4, (5,8)).to(torch.int32))
+    module.forward(torch.randint(2, 4, (5, 8)).to(torch.int32))
 
 
 class ElementwiseEqFloatTensorModule(torch.nn.Module):
@@ -583,9 +610,9 @@ class ElementwiseEqFloatTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqFloatTensorModule())
 def ElementwiseEqFloatTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]])
-                   .to(torch.float32), 
-                   torch.tensor([1.0, 2.4, 6.0]).to(torch.float32))
+    module.forward(
+        torch.tensor([[1.0, 2.2, 6.0], [6.0, 2.0, 3.1]]).to(torch.float32),
+        torch.tensor([1.0, 2.4, 6.0]).to(torch.float32))
 
 
 class ElementwiseEqIntTensorModule(torch.nn.Module):
@@ -604,9 +631,11 @@ class ElementwiseEqIntTensorModule(torch.nn.Module):
 
 @register_test_case(module_factory=lambda: ElementwiseEqIntTensorModule())
 def ElementwiseEqIntTensorModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(2, 4, (8, 5)), torch.randint(2, 4, (5,)))
+    module.forward(torch.randint(2, 4, (8, 5)), torch.randint(2, 4, (5, )))
+
 
 # ==============================================================================
+
 
 class ElementwiseClampModule(torch.nn.Module):
     def __init__(self):
@@ -666,7 +695,7 @@ class RsubModule_noalpha(torch.nn.Module):
 @register_test_case(module_factory=lambda: RsubModule_noalpha())
 def RsubModule_noalpha_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
-    
+
 # ==============================================================================
 
 class ElementwiseMulScalarIntModule(torch.nn.Module):
@@ -734,12 +763,10 @@ class ElementwiseMulTensorFloatModule(torch.nn.Module):
         return torch.mul(a, b)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseMulTensorFloatModule())
+@register_test_case(module_factory=lambda: ElementwiseMulTensorFloatModule())
 def ElementwiseMulTensorFloatModule_basic(module, tu: TestUtils):
-    module.forward(
-        tu.rand(4),
-        tu.rand(4).type(torch.float64))
+    module.forward(tu.rand(4), tu.rand(4).type(torch.float64))
+
 
 class ElementwiseMulTensorIntModule(torch.nn.Module):
     def __init__(self):
@@ -755,12 +782,10 @@ class ElementwiseMulTensorIntModule(torch.nn.Module):
         return torch.mul(a, b)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseMulTensorIntModule())
+@register_test_case(module_factory=lambda: ElementwiseMulTensorIntModule())
 def ElementwiseMulTensorIntModule_basic(module, tu: TestUtils):
     module.forward(
-      torch.randint(10, [4]).type(torch.int32),
-      torch.randint(10, [4]))
+        torch.randint(10, [4]).type(torch.int32), torch.randint(10, [4]))
 
 
 # ==============================================================================
@@ -783,7 +808,7 @@ def ElementwiseLogModule_basic(module, tu: TestUtils):
 
 
 class ElementwiseSqrtModule(torch.nn.Module):
-    def __init__(self): 
+    def __init__(self):
         super().__init__()
 
     @export
@@ -898,7 +923,7 @@ def ElementwiseLog2Module_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4))
 
 class ElementwiseRsqrtModule(torch.nn.Module):
-    def __init__(self): 
+    def __init__(self):
         super().__init__()
 
     @export
@@ -984,12 +1009,9 @@ class ElementwiseDivTensorFloatModule(torch.nn.Module):
         return torch.div(a, b)
 
 
-@register_test_case(
-    module_factory=lambda: ElementwiseDivTensorFloatModule())
+@register_test_case(module_factory=lambda: ElementwiseDivTensorFloatModule())
 def ElementwiseDivTensorFloatModule_basic(module, tu: TestUtils):
-    module.forward(
-        tu.rand(4),
-        tu.rand(4).type(torch.float64))
+    module.forward(tu.rand(4), tu.rand(4).type(torch.float64))
 
 
 # ==============================================================================
@@ -1005,15 +1027,15 @@ class ElementwiseAndIntegerModule(torch.nn.Module):
         ([-1, -1], torch.int32, True),
         ([-1, -1], torch.int64, True),
     ])
-
     def forward(self, x, y):
         return torch.bitwise_and(x, y)
 
 
 @register_test_case(module_factory=lambda: ElementwiseAndIntegerModule())
 def ElementwiseAndIntegerModule_basic(module, tu: TestUtils):
-    module.forward(torch.randint(-10, 10, (3, 4)).to(torch.int32),
-                   torch.randint(-10, 10, (3, 4)))
+    module.forward(
+        torch.randint(-10, 10, (3, 4)).to(torch.int32),
+        torch.randint(-10, 10, (3, 4)))
 
 
 class ElementwiseSubScalarIntModule(torch.nn.Module):
@@ -1026,7 +1048,8 @@ class ElementwiseSubScalarIntModule(torch.nn.Module):
         ([-1, -1], torch.int64, True),
     ])
     def forward(self, x):
-        return torch.sub(x, 2.1, alpha = 2)
+        return torch.sub(x, 2.1, alpha=2)
+
 
 @register_test_case(module_factory=lambda: ElementwiseSubScalarIntModule())
 def ElementwiseSubScalarIntModule_basic(module, tu: TestUtils):
@@ -1077,7 +1100,8 @@ class ElementwiseAddScalarFloatModule(torch.nn.Module):
         ([-1, -1], torch.float32, True),
     ])
     def forward(self, x):
-        return torch.add(x, 3.0, alpha = 2)
+        return torch.add(x, 3.0, alpha=2)
+
 
 @register_test_case(module_factory=lambda: ElementwiseAddScalarFloatModule())
 def ElementwiseAddScalarFloatModule_basic(module, tu: TestUtils):

--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -47,6 +47,7 @@ from . import nll_loss
 from . import index_select
 from . import arange
 from . import constant_alloc
+from . import threshold
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend', 'tosa', 'external']

--- a/e2e_testing/torchscript/threshold.py
+++ b/e2e_testing/torchscript/threshold.py
@@ -1,0 +1,291 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+import torch
+
+from torch_mlir_e2e_test.torchscript.framework import TestUtils
+from torch_mlir_e2e_test.torchscript.registry import register_test_case
+from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+
+class Threshold1dIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+    ])
+
+    def forward(self, input):
+        return torch.ops.aten.threshold(input, 1, 2)
+
+@register_test_case(module_factory=lambda: Threshold1dIntModule())
+def Threshold1dIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (4,)))
+
+
+class Threshold2dIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+    ])
+
+    def forward(self, input):
+        return torch.ops.aten.threshold(input, 0.5, 2)
+
+@register_test_case(module_factory=lambda: Threshold2dIntModule())
+def Threshold2dIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (4, 5)))
+
+
+class Threshold3dIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+    ])
+
+    def forward(self, input):
+        return torch.ops.aten.threshold(input, 1, 2.2)
+
+@register_test_case(module_factory=lambda: Threshold3dIntModule())
+def Threshold3dIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (4, 5, 6)))
+
+
+class Threshold1dFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, input):
+        return torch.ops.aten.threshold(input, 1, 2)
+
+@register_test_case(module_factory=lambda: Threshold1dFloatModule())
+def Threshold1dFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4))
+
+
+class Threshold2dFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, input):
+        return torch.ops.aten.threshold(input, 0.5, 2)
+
+@register_test_case(module_factory=lambda: Threshold2dFloatModule())
+def Threshold2dFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4, 5))
+
+
+class Threshold3dFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+
+    def forward(self, input):
+        return torch.ops.aten.threshold(input, 1.4, 2.0)
+
+@register_test_case(module_factory=lambda: Threshold3dFloatModule())
+def Threshold3dFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4, 5, 6))
+
+
+class ThresholdBackward1dIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.int64, True),
+        ([-1], torch.int64, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 1)
+
+@register_test_case(module_factory=lambda: ThresholdBackward1dIntModule())
+def ThresholdBackward1dIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (4,)), torch.randint(8, (4,)))
+
+
+class ThresholdBackward2dIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1, -1], torch.int64, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 0.5)
+
+@register_test_case(module_factory=lambda: ThresholdBackward2dIntModule())
+def ThresholdBackward2dIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (4, 5)), torch.randint(8, (4, 5)))
+
+
+class ThresholdBackward3dIntModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.int64, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 1)
+
+@register_test_case(module_factory=lambda: ThresholdBackward3dIntModule())
+def ThresholdBackward3dIntModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(10, (4, 5, 6)), torch.randint(8, (4, 5, 6)))
+
+
+class ThresholdBackward1dFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.float32, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 1)
+
+@register_test_case(module_factory=lambda: ThresholdBackward1dFloatModule())
+def ThresholdBackward1dFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4), torch.randn(4))
+
+
+class ThresholdBackward2dFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 0.5)
+
+@register_test_case(module_factory=lambda: ThresholdBackward2dFloatModule())
+def ThresholdBackward2dFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4, 5), torch.randn(4, 5))
+
+
+class ThresholdBackward3dFloatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 1.4)
+
+@register_test_case(module_factory=lambda: ThresholdBackward3dFloatModule())
+def ThresholdBackward3dFloatModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4, 5, 6), torch.randn(4, 5, 6))
+
+
+class ThresholdBackward1dMixedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1], torch.float32, True),
+        ([-1], torch.int64, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 1)
+
+@register_test_case(module_factory=lambda: ThresholdBackward1dMixedModule())
+def ThresholdBackward1dMixedModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4), torch.randint(10, (4,)))
+
+
+class ThresholdBackward2dMixedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.int64, True),
+        ([-1, -1], torch.float32, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 0.5)
+
+@register_test_case(module_factory=lambda: ThresholdBackward2dMixedModule())
+def ThresholdBackward2dMixedModule_basic(module, tu: TestUtils):
+    module.forward(torch.randint(20, (4, 5)), torch.randn(4, 5))
+
+
+class ThresholdBackward3dMixedModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+
+    def forward(self, grad, input):
+        return torch.ops.aten.threshold_backward(grad, input, 1.4)
+
+@register_test_case(module_factory=lambda: ThresholdBackward3dMixedModule())
+def ThresholdBackward3dMixedModule_basic(module, tu: TestUtils):
+    module.forward(torch.randn(4, 5, 6), torch.randint(10, (4, 5, 6)))

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -45,4 +45,7 @@ TOSA_PASS_SET = {
     "TModuleRank0_basic",
     "ElementwiseToDtypeIdentityModule_basic",
     "View1DFoldModule_basic",
+    "SqueezeDimModule_static",
+    "SqueezeDimModule_identity",
+    "SqueezeDimModule_unitDim",
 }

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -28,6 +28,7 @@ TOSA_PASS_SET = {
     "ElementwiseReluModule_basic",
     "ElementwiseFloorModule_basic",
     "ElementwiseLogModule_basic",
+    "ElementwiseBinaryStaticShapeModule_basic",
     "TanhBackward_basic",
     "ElementwiseAddModule_basic",
     "ReturnThreeTensorFloat32_basic",

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1140,6 +1140,38 @@ def Torch_AtenBitwiseAnd_TensorOp : Torch_Op<"aten.bitwise_and_.Tensor", [
   let assemblyFormat = "$self `,` $other attr-dict `:` type($self) `,` type($other) `->` type($result)";
 }
 
+def Torch_AtenThresholdOp : Torch_Op<"aten.threshold", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::threshold : (Tensor, Scalar, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$threshold,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $threshold `,` $value attr-dict `:` type($self) `,` type($threshold) `,` type($value) `->` type($result)";
+}
+
+def Torch_AtenThreshold_Op : Torch_Op<"aten.threshold_", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::threshold_ : (Tensor, Scalar, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$threshold,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $threshold `,` $value attr-dict `:` type($self) `,` type($threshold) `,` type($value) `->` type($result)";
+}
+
 def Torch_AtenAddcmulOp : Torch_Op<"aten.addcmul", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -1247,6 +1279,22 @@ def Torch_AtenPowTensorScalarOp : Torch_Op<"aten.pow.Tensor_Scalar", [
     AnyTorchTensorType:$result
   );
   let assemblyFormat = "$self `,` $exponent attr-dict `:` type($self) `,` type($exponent) `->` type($result)";
+}
+
+def Torch_AtenThresholdBackwardOp : Torch_Op<"aten.threshold_backward", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::threshold_backward : (Tensor, Tensor, Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$grad_output,
+    AnyTorchTensorType:$self,
+    AnyTorchScalarType:$threshold
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$grad_output `,` $self `,` $threshold attr-dict `:` type($grad_output) `,` type($self) `,` type($threshold) `->` type($result)";
 }
 
 def Torch_AtenTriuOp : Torch_Op<"aten.triu", [

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1778,6 +1778,22 @@ def Torch_AtenNllLossForwardOp : Torch_Op<"aten.nll_loss_forward", [
   let assemblyFormat = "$self `,` $target `,` $weight `,` $reduction `,` $ignore_index attr-dict `:` type($self) `,` type($target) `,` type($weight) `,` type($reduction) `,` type($ignore_index) `->` type($output) `,` type($total_weight)";
 }
 
+def Torch_AtenConstantPadNdOp : Torch_Op<"aten.constant_pad_nd", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    TorchIntListType:$pad,
+    AnyTorchScalarType:$value
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $pad `,` $value attr-dict `:` type($self) `,` type($pad) `,` type($value) `->` type($result)";
+}
+
 def Torch_AtenSqueezeDimOp : Torch_Op<"aten.squeeze.dim", [
     AllowsTypeRefinement
   ]> {
@@ -2915,6 +2931,22 @@ def Torch_AtenAddStrOp : Torch_Op<"aten.add.str", [
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
 }
 
+def Torch_AtenEqStrOp : Torch_Op<"aten.eq.str", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::eq.str : (str, str) -> (bool)`";
+  let arguments = (ins
+    Torch_StringType:$a,
+    Torch_StringType:$b
+  );
+  let results = (outs
+    Torch_BoolType:$result
+  );
+  let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenStrOp : Torch_Op<"aten.str", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -3175,6 +3207,21 @@ def Torch_AtenMulIntOp : Torch_Op<"aten.mul.int", [
   let hasFolder = 1;
 }
 
+def Torch_AtenNegIntOp : Torch_Op<"aten.neg.int", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::neg.int : (int) -> (int)`";
+  let arguments = (ins
+    Torch_IntType:$a
+  );
+  let results = (outs
+    Torch_IntType:$result
+  );
+  let assemblyFormat = "$a attr-dict `:` type($a) `->` type($result)";
+  let hasFolder = 1;
+}
+
 def Torch_AtenLogIntOp : Torch_Op<"aten.log.int", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -3246,6 +3293,22 @@ def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
     Torch_BoolType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+}
+
+def Torch_AtenEqFloatOp : Torch_Op<"aten.eq.float", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::eq.float : (float, float) -> (bool)`";
+  let arguments = (ins
+    Torch_FloatType:$a,
+    Torch_FloatType:$b
+  );
+  let results = (outs
+    Torch_BoolType:$result
+  );
+  let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_Aten__And__BoolOp : Torch_Op<"aten.__and__.bool", [

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedPrimOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedPrimOps.td
@@ -185,6 +185,7 @@ def Torch_PrimUninitializedOp : Torch_Op<"prim.Uninitialized", [
     AnyTorchType:$result
   );
   let assemblyFormat = " attr-dict `:` type($result)";
+  let hasCanonicalizer = 1;
 }
 
 def Torch_PrimUncheckedCastOp : Torch_Op<"prim.unchecked_cast", [

--- a/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
+++ b/include/torch-mlir/Dialect/Torch/IR/TorchOps.h
@@ -45,12 +45,33 @@ struct torch_constant_int_op_binder {
     return false;
   }
 };
+
+struct torch_constant_float_op_binder {
+  APFloat *bind_value;
+
+  /// Creates a matcher instance that binds the value to bv if match succeeds.
+  torch_constant_float_op_binder(APFloat *bv) : bind_value(bv) {}
+
+  bool match(Operation *op) {
+    if (auto constantFloat = dyn_cast<Torch::ConstantFloatOp>(op)) {
+      *bind_value = constantFloat.value();
+      return true;
+    }
+    return false;
+  }
+};
 } // namespace detail
 
 /// Matches the integer stored in a `torch.constant.bool`.
 inline detail::torch_constant_int_op_binder
 m_TorchConstantInt(int64_t *bind_value) {
   return detail::torch_constant_int_op_binder(bind_value);
+}
+
+/// Matches the integer stored in a `torch.constant.float`.
+inline detail::torch_constant_float_op_binder
+m_TorchConstantFloat(APFloat *bind_value) {
+  return detail::torch_constant_float_op_binder(bind_value);
 }
 
 namespace detail {

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -2345,7 +2345,7 @@ struct ConvertElementwiseOp : ConversionPattern {
         // undefined behavior, by doing appropriate checks against the current
         // dimension size.
         auto currentDimSize =
-            rewriter.create<tensor::DimOp>(loc, tensorOperand, size.index());
+            getDimOp(rewriter, loc, tensorOperand, size.index());
 
         // If the result size of this dimension has so far only hit the
         // statically-known-to-be-1 case above (i.e., we have not yet assigned a
@@ -2372,12 +2372,13 @@ struct ConvertElementwiseOp : ConversionPattern {
           /*dimCount=*/resultRank, /*symbolCount=*/0, exprs, getContext()));
     }
 
-    SmallVector<StringRef> iteratorTypes(resultRank, "parallel");
+    SmallVector<StringRef> iteratorTypes(resultRank,
+                                         getParallelIteratorTypeName());
     // Add the indexing map for the outs init tensor.
     indexingMaps.push_back(rewriter.getMultiDimIdentityMap(resultRank));
 
     Value initTensor = rewriter.create<linalg::InitTensorOp>(
-        loc, resultShape, resultType.getElementType());
+        loc, getAsOpFoldResult(resultShape), resultType.getElementType());
     bool hadErrorCreatingPayload = false;
     auto generic = rewriter.create<linalg::GenericOp>(
         loc, /*resultTensorTypes=*/initTensor.getType(),

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -275,7 +275,24 @@ static SmallVector<Value> getTypeConvertedValues(OpBuilder &b, Location loc,
 }
 
 // Helper function to get the padding tensor given the padding int values.
-// It's assumed that the padding on the low end and high end are the same.
+static Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
+                             SmallVectorImpl<int64_t> &lowPaddingInts,
+                             SmallVectorImpl<int64_t> &highPaddingInts,
+                             Value pad) {
+  Location loc = op->getLoc();
+  Type rankedTensorType = linalg::PadTensorOp::inferResultType(
+      input.getType().cast<RankedTensorType>(), lowPaddingInts, highPaddingInts);
+  SmallVector<OpFoldResult> lowPaddings = getAsOpFoldResult(b, loc, lowPaddingInts);
+  SmallVector<OpFoldResult> highPaddings = getAsOpFoldResult(b, loc, highPaddingInts);
+  Value paddedInput = linalg::PadTensorOp::createPadScalarOp(
+      rankedTensorType, input, pad, /*low=*/lowPaddings, /*high=*/highPaddings,
+      /*packing=*/false, loc, b);
+  return paddedInput;
+}
+
+// Helper function to get the padding tensor given the padding int values.
+// It's assumed that the padding on the low end and high end are the same,
+// and that zero padding is required.
 static Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
                              SmallVectorImpl<int64_t> &paddingInts) {
   assert(input.getType().isa<RankedTensorType>() &&
@@ -284,13 +301,7 @@ static Value getPaddedTensor(Operation *op, OpBuilder &b, Value &input,
   Value c0 = b.create<arith::ConstantOp>(
       loc,
       b.getZeroAttr(input.getType().cast<RankedTensorType>().getElementType()));
-  SmallVector<OpFoldResult> paddings = getAsOpFoldResult(b, loc, paddingInts);
-  Type ranked4DTensorType = linalg::PadTensorOp::inferResultType(
-      input.getType().cast<RankedTensorType>(), paddingInts, paddingInts);
-  Value paddedInput = linalg::PadTensorOp::createPadScalarOp(
-      ranked4DTensorType, input, c0, /*low=*/paddings, /*high=*/paddings,
-      /*packing=*/false, loc, b);
-  return paddedInput;
+  return getPaddedTensor(op, b, input, paddingInts, paddingInts, c0);
 }
 
 static Value buildNormalCdf(OpBuilder &b, Location &loc, Value x, Value mean,
@@ -2686,6 +2697,58 @@ public:
 } // namespace
 
 namespace {
+class ConvertAtenConstantPadNdOp : public OpConversionPattern<AtenConstantPadNdOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AtenConstantPadNdOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
+      return failure();
+    Location loc = op->getLoc();
+    Value self = adaptor.self();
+    auto type = self.getType().cast<RankedTensorType>();
+    int64_t rank = type.getRank();
+
+    Type elementType = self.getType().cast<RankedTensorType>().getElementType();
+    if (!elementType.isa<mlir::FloatType>())
+      return op.emitError("unimplemented: non-floating point type");
+
+    // Pattern match against the op's original operands, because otherwise we
+    // will get the lowered version of the operands which is harder to pattern
+    // match.
+    SmallVector<int64_t> padInts;
+    if (!matchPattern(op.pad(), m_TorchConstantIntList(padInts)))
+      return rewriter.notifyMatchFailure(op,
+                                         "only support constant int pad ranges");
+    uint64_t padRank = padInts.size() / 2;
+    if (padRank * 2 != padInts.size())
+      return rewriter.notifyMatchFailure(op, "pad range size is not even");
+    if (rank < 0 || padRank > (uint64_t)rank)
+      return rewriter.notifyMatchFailure(op, "padding exceeds tensor rank");
+
+    // low/high initialized with the dims that should not be padded
+    SmallVector<int64_t, 4> lowPadding(/*Size=*/rank - padRank, /*Value=*/0);
+    SmallVector<int64_t, 4> highPadding(/*Size=*/rank - padRank, /*Value=*/0);
+    // add requested padding - note op.pad() is higest dim first ordered pairs
+    // of low,high
+    for (uint64_t i = padRank; i > 0; --i) {
+      lowPadding.push_back(padInts[i * 2 - 2]);
+      highPadding.push_back(padInts[i * 2 - 1]);
+    }
+
+    Value castedValue =
+        rewriter.create<arith::TruncFOp>(loc, type.getElementType(), adaptor.value());
+    Value paddedInput = getPaddedTensor(op, rewriter, self, lowPadding, highPadding, castedValue);
+
+    Type newResultType = getTypeConverter()->convertType(op.getType());
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, paddedInput);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertAtenFlattenUsingIntsOp
     : public OpConversionPattern<AtenFlattenUsingIntsOp> {
 public:
@@ -4225,6 +4288,8 @@ public:
     patterns.add<ConvertAtenViewOp>(typeConverter, context);
     target.addIllegalOp<AtenMaxPool2dOp>();
     patterns.add<ConvertAtenMaxPool2dOp>(typeConverter, context);
+    target.addIllegalOp<AtenConstantPadNdOp>();
+    patterns.add<ConvertAtenConstantPadNdOp>(typeConverter, context);
     target.addIllegalOp<AtenSumOp>();
     patterns.add<ConvertReductionOp>(typeConverter, context);
     target.addIllegalOp<AtenTransposeIntOp>();

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -117,8 +117,9 @@ class ConvertAtenAddSubOp : public OpConversionPattern<AtenOpT> {
 public:
   using OpConversionPattern<AtenOpT>::OpConversionPattern;
   using OpAdaptor = typename AtenOpT::Adaptor;
-  LogicalResult matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     Value lhs = adaptor.self();
     auto lhsTy = lhs.getType().cast<TensorType>();
     Value rhs = adaptor.other();
@@ -312,8 +313,9 @@ public:
 
   // Common rewriter for all reduction ops, calls the specific implementation of
   // readReduceDimsAndKeepDims() needed for the op variant.
-  LogicalResult matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     Value self = adaptor.self();
     auto selfTy = self.getType().cast<TensorType>();
 
@@ -360,7 +362,7 @@ class ConvertAtenMultipleDimsReductionOp
   LogicalResult readReduceDimsAndKeepDims(AtenOpT op, OpAdaptor adaptor,
                                           ConversionPatternRewriter &rewriter,
                                           ElementsAttr &reduceDimsAttr,
-                                          bool &keepDims) const {
+                                          bool &keepDims) const override {
     SmallVector<int64_t, 4> reduceDims;
     if (!matchPattern(op.dim(), m_TorchConstantIntList(reduceDims)))
       return rewriter.notifyMatchFailure(op,
@@ -391,7 +393,7 @@ class ConvertAtenOneDimReductionOp
   LogicalResult readReduceDimsAndKeepDims(AtenOpT op, OpAdaptor adaptor,
                                           ConversionPatternRewriter &rewriter,
                                           ElementsAttr &reduceDimsAttr,
-                                          bool &keepDims) const {
+                                          bool &keepDims) const override {
     int64_t reduceDim;
     if (!matchPattern(op.dim(), m_TorchConstantInt(&reduceDim)))
       return rewriter.notifyMatchFailure(op,
@@ -421,7 +423,7 @@ public:
   LogicalResult readReduceDimsAndKeepDims(AtenOpT op, OpAdaptor adaptor,
                                           ConversionPatternRewriter &rewriter,
                                           ElementsAttr &reduceDimsAttr,
-                                          bool &keepDims) const {
+                                          bool &keepDims) const override {
     auto self = adaptor.self();
     auto selfTy = self.getType().template cast<RankedTensorType>();
 
@@ -543,8 +545,9 @@ public:
 
   // Common rewriter for all squeeze ops, calls the specific implementation of
   // generateSqueezedShape() needed for the op variant.
-  LogicalResult matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  matchAndRewrite(AtenOpT op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     Value self = adaptor.self();
     auto selfTy = self.getType().template cast<RankedTensorType>();
 
@@ -585,7 +588,7 @@ class ConvertAtenSqueezeOneDimOp : public ConvertAtenSqueezeOp<AtenOpT> {
   LogicalResult
   generateSqueezedShape(AtenOpT op, RankedTensorType selfTy,
                         ConversionPatternRewriter &rewriter,
-                        SmallVector<int64_t> &squeezedShape) const {
+                        SmallVector<int64_t> &squeezedShape) const override {
     int64_t squeezeDim;
     if (!matchPattern(op.dim(), m_TorchConstantInt(&squeezeDim)))
       return rewriter.notifyMatchFailure(op,
@@ -619,7 +622,7 @@ class ConvertAtenSqueezeAllDimsOp : public ConvertAtenSqueezeOp<AtenOpT> {
   LogicalResult
   generateSqueezedShape(AtenOpT op, RankedTensorType selfTy,
                         ConversionPatternRewriter &rewriter,
-                        SmallVector<int64_t> &squeezedShape) const {
+                        SmallVector<int64_t> &squeezedShape) const override {
     auto selfShape = selfTy.getShape();
 
     // Dims that may dynamically resolve to 1 are not reduced here. Only

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -242,7 +242,7 @@ public:
             AtenClampOp, AtenLogOp, AtenNegOp, AtenSqrtOp, AtenFloorOp,
             AtenLog2Op, Aten_SoftmaxBackwardDataOp, AtenRsqrtOp, AtenDropoutOp,
             AtenTanhBackwardOp, Aten_LogSoftmaxBackwardDataOp, AtenAddIntOp,
-            AtenAbsOp>(op)) {
+            AtenAbsOp, AtenThresholdOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 
@@ -318,7 +318,8 @@ public:
       return visitBinaryTensorScalarOp(op, operands);
     } else if (isa<AtenAddTensorOp, AtenSubTensorOp, AtenMulTensorOp,
                    AtenDivTensorOp, Aten__And__TensorOp, AtenMinimumOp,
-                   AtenMaximumOp, AtenBitwiseAndTensorOp>(op)) {
+                   AtenMaximumOp, AtenBitwiseAndTensorOp,
+                   AtenThresholdBackwardOp>(op)) {
       return visitBinaryBroadcastingOp(op, operands);
     } else if (isa<AtenEqTensorOp, AtenGtTensorOp, AtenLtTensorOp>(op)) {
       return visitBinaryBroadcastingComparisonOp(op, operands);

--- a/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/VerifyLinalgOnTensorsBackendContract.cpp
@@ -64,6 +64,7 @@ class VerifyLinalgOnTensorsBackendContractPass
     // Tensor operations should go through linalg and the tensor dialect.
     target.addDynamicallyLegalDialect<linalg::LinalgDialect>(opHasLegalTypes);
     target.addDynamicallyLegalDialect<tensor::TensorDialect>(opHasLegalTypes);
+    target.addDynamicallyLegalDialect<AffineDialect>(opHasLegalTypes);
 
     // AssertOp is used to terminate the program for error guards.
     target.addLegalOp<AssertOp>();

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -414,7 +414,7 @@ def emit_prim_ops(torch_ir_dir: str, registry: Registry):
         emit("prim::max.self_int : (int[]) -> (int)")
         emit("prim::max.int : (int, int) -> (int)")
         emit("prim::RaiseException : (str) -> ()")
-        emit("prim::Uninitialized : () -> (Any)")
+        emit("prim::Uninitialized : () -> (Any)", has_canonicalizer=True)
         emit("prim::unchecked_cast : (t) -> (t)",
              traits=["DeclareOpInterfaceMethods<CastOpInterface>"])
         emit("prim::Print : (...) -> ()")
@@ -540,6 +540,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::nll_loss_forward : (Tensor, Tensor, Tensor?, int, int) -> (Tensor, Tensor)")
 
         # Misc tensor ops.
+        emit("aten::constant_pad_nd : (Tensor, int[], Scalar) -> (Tensor)")
         emit("aten::squeeze.dim : (Tensor, int) -> (Tensor)", has_folder=True)
         emit("aten::unsqueeze : (Tensor, int) -> (Tensor)")
         emit("aten::squeeze : (Tensor) -> (Tensor)", has_folder=True)
@@ -619,6 +620,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
 
         # Str ops.
         emit("aten::add.str : (str, str) -> (str)")
+        emit("aten::eq.str : (str, str) -> (bool)", has_folder=True)
         emit("aten::str : (t) -> (str)")
         emit("aten::format : (...) -> (str)")
         emit("aten::join : (str, str[]) -> (str)")
@@ -640,11 +642,13 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::add.int : (int, int) -> (int)", has_folder=True)
         emit("aten::sub.int : (int, int) -> (int)", has_folder=True)
         emit("aten::mul.int : (int, int) -> (int)", has_folder=True)
+        emit("aten::neg.int : (int) -> (int)", has_folder=True)
         emit("aten::log.int : (int) -> (float)")
         emit("aten::add.float_int : (float, int) -> (float)")
         emit("aten::mul.float : (float, float) -> (float)")
         emit("aten::neg.float : (float) -> (float)")
         emit("aten::lt.float_int : (float, int) -> (bool)")
+        emit("aten::eq.float : (float, float) -> (bool)", has_folder=True)
         emit("aten::__and__.bool : (bool, bool) -> (bool)")
         emit("aten::ne.bool : (bool, bool) -> (bool)", has_folder=True)
         emit("aten::__is__ : (t1, t2) -> (bool)", has_folder=True)

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -480,6 +480,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
                 "aten::abs : (Tensor) -> (Tensor)",
                 "aten::reciprocal : (Tensor) -> (Tensor)",
                 "aten::bitwise_and.Tensor : (Tensor, Tensor) -> (Tensor)",
+                "aten::threshold : (Tensor, Scalar, Scalar) -> (Tensor)",
 
         ]:
             emit_with_mutating_variants(key)
@@ -492,6 +493,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::rsub.Scalar : (Tensor, Scalar, Scalar) -> (Tensor)")
         emit("aten::gelu : (Tensor) -> (Tensor)")
         emit("aten::pow.Tensor_Scalar : (Tensor, Scalar) -> (Tensor)")
+        emit("aten::threshold_backward : (Tensor, Tensor, Scalar) -> (Tensor)")
 
         emit_with_mutating_variants("aten::triu : (Tensor, int) -> (Tensor)")
         emit_with_mutating_variants("aten::index_put : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)")

--- a/test/Dialect/Torch/promote-types.mlir
+++ b/test/Dialect/Torch/promote-types.mlir
@@ -7,7 +7,7 @@
 // CHECK-SAME:                                                      %[[VAL_1:.*]]: !torch.vtensor<[1],f64>,
 // CHECK-SAME:                                                      %[[VAL_2:.*]]: !torch.float) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[?],f64>
+// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],f64>
 // CHECK:           return
 builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1],f32>,
                                             %t1: !torch.vtensor<[1],f64>,
@@ -23,7 +23,7 @@ builtin.func @tensor_tensor$same_category_different_width(%t0: !torch.vtensor<[1
 // CHECK-SAME:                                           %[[VAL_1:.*]]: !torch.vtensor<[1],f64>,
 // CHECK-SAME:                                           %[[VAL_2:.*]]: !torch.float) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[?],f64>
+// CHECK-SAME:         !torch.vtensor<[1],si32>, !torch.vtensor<[1],f64>, !torch.float -> !torch.vtensor<[1],f64>
 // CHECK:           return
 builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
                                  %t1: !torch.vtensor<[1],f64>,
@@ -39,7 +39,7 @@ builtin.func @tensor_tensor$different_category(%t0: !torch.vtensor<[1],si32>,
 // CHECK-SAME:                                                      %[[VAL_1:.*]]: !torch.vtensor<[],f64>,
 // CHECK-SAME:                                                      %[[VAL_2:.*]]: !torch.int) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK-SAME:         !torch.vtensor<[1],f32>, !torch.vtensor<[],f64>, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_tensor$same_category_zero_rank_wider(
                                                   %t0: !torch.vtensor<[1],f32>,
@@ -56,7 +56,7 @@ builtin.func @tensor_tensor$same_category_zero_rank_wider(
 // CHECK-SAME:                                                  %[[VAL_1:.*]]: !torch.vtensor<[],f32>,
 // CHECK-SAME:                                                  %[[VAL_2:.*]]: !torch.int) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:         !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[?],f32>
+// CHECK-SAME:         !torch.vtensor<[1],si64>, !torch.vtensor<[],f32>, !torch.int -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si64>,
                                         %t1: !torch.vtensor<[],f32>,
@@ -71,7 +71,7 @@ builtin.func @tensor_tensor$zero_rank_higher_category(%t0: !torch.vtensor<[1],si
 // CHECK-SAME:                                    %[[VAL_0:.*]]: !torch.vtensor<[1],f32>, %[[VAL_1:.*]]: !torch.vtensor<[1],f32>,
 // CHECK-SAME:                                    %[[VAL_2:.*]]: !torch.float) {
 // CHECK:           %[[VAL_3:.*]] = torch.aten.add.Tensor %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] :
-// CHECK-SAME:        !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[?],f32>
+// CHECK-SAME:        !torch.vtensor<[1],f32>, !torch.vtensor<[1],f32>, !torch.float -> !torch.vtensor<[1],f32>
 // CHECK:           return
 builtin.func @tensor_tensor$alpha_wider_no_contribution(%t0: !torch.vtensor<[1],f32>,
                                %t1: !torch.vtensor<[1],f32>,


### PR DESCRIPTION
Note that to enable folding of the code coming from an example
like the ConstantPad2dStaticModule e2e test, support for other
operations had to be added/improved:
- aten::neg.int
- aten::eq.float
- aten::eq.str
- prim::Uninitialized