### PR TITLE
build tmtensor as subdirectory of torch-mlir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,19 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
 
 macro(torch_mlir_add_llvm_external_project name identifier location)
-  message(STATUS "Adding LLVM external project ${name} (${identifier}) -> ${location}")
-  if(NOT EXISTS "${location}/CMakeLists.txt")
-    message(FATAL_ERROR "External project location ${location} is not valid")
-  endif()
-  list(APPEND LLVM_EXTERNAL_PROJECTS ${name})
-  list(REMOVE_DUPLICATES LLVM_EXTERNAL_PROJECTS)
-  set(LLVM_EXTERNAL_${identifier}_SOURCE_DIR ${location} CACHE STRING "" FORCE)
-  set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
-endmacro()
+message(STATUS "Adding LLVM external project ${name} (${identifier}) -> ${location}")
+if(NOT EXISTS "${location}/CMakeLists.txt")
+message(FATAL_ERROR "External project location ${location} is not valid")
+endif()  
+list(APPEND LLVM_EXTERNAL_PROJECTS ${name})
+list(REMOVE_DUPLICATES LLVM_EXTERNAL_PROJECTS)
+set(LLVM_EXTERNAL_${identifier}_SOURCE_DIR ${location} CACHE STRING "" FORCE)
+set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
+endmacro()  
+
+set(TORCH_MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(TORCH_MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+message(STATUS "Building torch-mlir project at ${TORCH_MLIR_SOURCE_DIR} (into ${TORCH_MLIR_BINARY_DIR})")
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Out-of-tree build
@@ -59,7 +63,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(LIT_ARGS_DEFAULT "-sv")
   if (MSVC_IDE OR XCODE)
     set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
-  endif()
+  endif()  
   set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
 
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
@@ -77,14 +81,14 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(TORCH-MLIR_BUILT_STANDALONE 1)
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
   add_subdirectory(external/llvm-external-projects/torch-mlir-dialects)
-else()
+else()  
   # In-tree build with LLVM_EXTERNAL_PROJECTS=torch-mlir
   torch_mlir_add_llvm_external_project(
     torch-mlir-dialects
     TORCH_MLIR_DIALECTS
     ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-external-projects/torch-mlir-dialects)
   
-  # FIXME: This should really be inherited from the LLVM tree.  In particular,
+  # FIXME: This should really be inherited from the LLVM tree.  In particular,  
   # it's going to change when cross-compiling.
   set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
@@ -96,11 +100,7 @@ else()
   set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
   set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR}")
-endif()
-
-set(TORCH_MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(TORCH_MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-message(STATUS "Building torch-mlir project at ${TORCH_MLIR_SOURCE_DIR} (into ${TORCH_MLIR_BINARY_DIR})")
+endif()  
 
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,17 +36,13 @@ macro(torch_mlir_add_llvm_external_project name identifier location)
   set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
 endmacro()
 
-torch_mlir_add_llvm_external_project(
-  torch-mlir-dialects
-  TORCH_MLIR_DIALECTS
-  ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-external-projects/torch-mlir-dialects)
-
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Out-of-tree build
 
   #-------------------------------------------------------------------------------
   # MLIR/LLVM Configuration
   #-------------------------------------------------------------------------------
+  set(LLVM_OUT_OF_TREE_BUILD TRUE)
 
   find_package(MLIR REQUIRED CONFIG)
   message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
@@ -83,6 +79,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   add_subdirectory(external/llvm-external-projects/torch-mlir-dialects)
 else()
   # In-tree build with LLVM_EXTERNAL_PROJECTS=torch-mlir
+  torch_mlir_add_llvm_external_project(
+    torch-mlir-dialects
+    TORCH_MLIR_DIALECTS
+    ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-external-projects/torch-mlir-dialects)
+  
   # FIXME: This should really be inherited from the LLVM tree.  In particular,
   # it's going to change when cross-compiling.
   set(MLIR_TABLEGEN_EXE mlir-tblgen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,15 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
 
 macro(torch_mlir_add_llvm_external_project name identifier location)
-message(STATUS "Adding LLVM external project ${name} (${identifier}) -> ${location}")
-if(NOT EXISTS "${location}/CMakeLists.txt")
-message(FATAL_ERROR "External project location ${location} is not valid")
-endif()  
-list(APPEND LLVM_EXTERNAL_PROJECTS ${name})
-list(REMOVE_DUPLICATES LLVM_EXTERNAL_PROJECTS)
-set(LLVM_EXTERNAL_${identifier}_SOURCE_DIR ${location} CACHE STRING "" FORCE)
-set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
-endmacro()  
+  message(STATUS "Adding LLVM external project ${name} (${identifier}) -> ${location}")
+  if(NOT EXISTS "${location}/CMakeLists.txt")
+    message(FATAL_ERROR "External project location ${location} is not valid")
+  endif()
+  list(APPEND LLVM_EXTERNAL_PROJECTS ${name})
+  list(REMOVE_DUPLICATES LLVM_EXTERNAL_PROJECTS)
+  set(LLVM_EXTERNAL_${identifier}_SOURCE_DIR ${location} CACHE STRING "" FORCE)
+  set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
+endmacro()
 
 set(TORCH_MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(TORCH_MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
@@ -63,7 +63,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(LIT_ARGS_DEFAULT "-sv")
   if (MSVC_IDE OR XCODE)
     set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
-  endif()  
+  endif()
   set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
 
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
@@ -81,14 +81,14 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(TORCH-MLIR_BUILT_STANDALONE 1)
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
   add_subdirectory(external/llvm-external-projects/torch-mlir-dialects)
-else()  
+else()
   # In-tree build with LLVM_EXTERNAL_PROJECTS=torch-mlir
   torch_mlir_add_llvm_external_project(
     torch-mlir-dialects
     TORCH_MLIR_DIALECTS
     ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-external-projects/torch-mlir-dialects)
-  
-  # FIXME: This should really be inherited from the LLVM tree.  In particular,  
+
+  # FIXME: This should really be inherited from the LLVM tree.  In particular,
   # it's going to change when cross-compiling.
   set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
@@ -100,7 +100,7 @@ else()
   set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
   set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR}")
-endif()  
+endif()
 
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,10 @@ macro(torch_mlir_add_llvm_external_project name identifier location)
   set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
 endmacro()
 
-set(TORCH_MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(TORCH_MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-message(STATUS "Building torch-mlir project at ${TORCH_MLIR_SOURCE_DIR} (into ${TORCH_MLIR_BINARY_DIR})")
+torch_mlir_add_llvm_external_project(
+  torch-mlir-dialects
+  TORCH_MLIR_DIALECTS
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-external-projects/torch-mlir-dialects)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Out-of-tree build
@@ -46,7 +47,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   #-------------------------------------------------------------------------------
   # MLIR/LLVM Configuration
   #-------------------------------------------------------------------------------
-  set(LLVM_OUT_OF_TREE_BUILD TRUE)
 
   find_package(MLIR REQUIRED CONFIG)
   message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
@@ -83,11 +83,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   add_subdirectory(external/llvm-external-projects/torch-mlir-dialects)
 else()
   # In-tree build with LLVM_EXTERNAL_PROJECTS=torch-mlir
-  torch_mlir_add_llvm_external_project(
-    torch-mlir-dialects
-    TORCH_MLIR_DIALECTS
-    ${CMAKE_CURRENT_SOURCE_DIR}/external/llvm-external-projects/torch-mlir-dialects)
-
   # FIXME: This should really be inherited from the LLVM tree.  In particular,
   # it's going to change when cross-compiling.
   set(MLIR_TABLEGEN_EXE mlir-tblgen)
@@ -102,6 +97,10 @@ else()
   set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR}")
 endif()
 
+set(TORCH_MLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(TORCH_MLIR_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+message(STATUS "Building torch-mlir project at ${TORCH_MLIR_SOURCE_DIR} (into ${TORCH_MLIR_BINARY_DIR})")
+
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -109,8 +108,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 function(torch_mlir_target_includes target)
   set(_dirs
-    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${MLIR_GENERATED_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${TORCH_MLIR_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_BINARY_DIR}/include>
   )

--- a/external/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
+++ b/external/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
@@ -1,10 +1,13 @@
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-message(FATAL_ERROR
-  "This project is intended to be built as part of LLVM via "
-  "-DLLVM_EXTERNAL_PROJECTS=torch-mlir-dialects "
-  "-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+  set(LLVM_OUT_OF_TREE_BUILD TRUE)
 endif()
 
+if(${LLVM_OUT_OF_TREE_BUILD})
+  set(TORCH_MLIR_DIALECTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(TORCH_MLIR_DIALECTS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  message(STATUS "Building torch-mlir-dialects project at ${TORCH_MLIR_DIALECTS_SOURCE_DIR} (into ${TORCH_MLIR_DIALECTS_BINARY_DIR})")
+  set(MLIR_GENERATED_INCLUDE_DIR ${MLIR_INCLUDE_DIR})
+else()
 option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
 
 set(TORCH_MLIR_DIALECTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -21,9 +24,21 @@ include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
 include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
 include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)
 
+# Configure CMake and tablegen.
+list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+set(MLIR_TABLEGEN_EXE mlir-tblgen)
+
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+endif()
+
 function(torch_mlir_dialects_target_includes target)
-  set(_dirs
-    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIR}>
+  set(_dirs 
+    $<BUILD_INTERFACE:${LLVM_BUILD_MAIN_SRC_DIR}/include>
+    $<BUILD_INTERFACE:${LLVM_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${MLIR_GENERATED_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_DIALECTS_BINARY_DIR}/include>
@@ -39,16 +54,13 @@ function(torch_mlir_dialects_target_includes target)
   endif()
 endfunction()
 
-# Configure CMake and tablegen.
-list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
-list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
-set(MLIR_TABLEGEN_EXE mlir-tblgen)
-
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
+include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
+include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
+include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)
 
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(test)
+
+# TODO: Needed for tablegen. Remove.

--- a/external/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
+++ b/external/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
@@ -1,18 +1,31 @@
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  set(LLVM_OUT_OF_TREE_BUILD TRUE)
+  # The cmake configuration to build torch-mlir-dialects as
+  # an out-of-tree project has not been implemented. It can
+  # be built as part of LLVM or as a subdirectory of torch-mlir.
+  message(FATAL_ERROR
+    "This project is intended to be built as part of LLVM via "
+    "-DLLVM_EXTERNAL_PROJECTS=torch-mlir-dialects "
+    "-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
+
+option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
 
 set(TORCH_MLIR_DIALECTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(TORCH_MLIR_DIALECTS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 message(STATUS "Building torch-mlir-dialects project at ${TORCH_MLIR_DIALECTS_SOURCE_DIR} (into ${TORCH_MLIR_DIALECTS_BINARY_DIR})")
-option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
 
-if(${LLVM_OUT_OF_TREE_BUILD})
-  set(MLIR_GENERATED_INCLUDE_DIR ${MLIR_INCLUDE_DIR})
+if(MLIR_FOUND)
+  message(STATUS "LLVM and MLIR packages have already been configured.")
 else()
+  message(STATUS "torch-mlir-dialect is being built in-tree")
+  # An in-tree build, LLVM hasn't been installed yet.
+  # We compute these properties manually, they're otherwise
+  # contributed by find_package(MLIR...)
   set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
-  set(MLIR_INCLUDE_DIRS ${LLVM_MAIN_SRC_DIR}/../mlir/include)
+  set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+  set(MLIR_INCLUDE_DIRS ${MLIR_INCLUDE_DIR} ${MLIR_GENERATED_INCLUDE_DIR})
+  set(LLVM_INCLUDE_DIRS ${LLVM_MAIN_INCLUDE_DIR})
 
   # Configure CMake and tablegen.
   list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
@@ -25,11 +38,8 @@ else()
 endif()
 
 function(torch_mlir_dialects_target_includes target)
-  set(_dirs 
-    $<BUILD_INTERFACE:${LLVM_BUILD_MAIN_SRC_DIR}/include>
-    $<BUILD_INTERFACE:${LLVM_INCLUDE_DIR}>
+  set(_dirs
     $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${MLIR_GENERATED_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_DIALECTS_BINARY_DIR}/include>
   )
@@ -46,12 +56,10 @@ endfunction()
 
 # TODO: Needed for tablegen. Remove.
 include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
-include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)
 
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(test)
-
-# TODO: Needed for tablegen. Remove.

--- a/external/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
+++ b/external/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
@@ -2,36 +2,26 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(LLVM_OUT_OF_TREE_BUILD TRUE)
 endif()
 
-if(${LLVM_OUT_OF_TREE_BUILD})
-  set(TORCH_MLIR_DIALECTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-  set(TORCH_MLIR_DIALECTS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-  message(STATUS "Building torch-mlir-dialects project at ${TORCH_MLIR_DIALECTS_SOURCE_DIR} (into ${TORCH_MLIR_DIALECTS_BINARY_DIR})")
-  set(MLIR_GENERATED_INCLUDE_DIR ${MLIR_INCLUDE_DIR})
-else()
-option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
-
 set(TORCH_MLIR_DIALECTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(TORCH_MLIR_DIALECTS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 message(STATUS "Building torch-mlir-dialects project at ${TORCH_MLIR_DIALECTS_SOURCE_DIR} (into ${TORCH_MLIR_DIALECTS_BINARY_DIR})")
+option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
 
-# TODO: Fix this upstream so that global include directories are not needed.
-set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
-set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
-set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+if(${LLVM_OUT_OF_TREE_BUILD})
+  set(MLIR_GENERATED_INCLUDE_DIR ${MLIR_INCLUDE_DIR})
+else()
+  set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
+  set(MLIR_INCLUDE_DIRS ${LLVM_MAIN_SRC_DIR}/../mlir/include)
+  set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
 
-# TODO: Needed for tablegen. Remove.
-include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
-include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
-include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)
+  # Configure CMake and tablegen.
+  list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
+  list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+  set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
-# Configure CMake and tablegen.
-list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
-list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
-set(MLIR_TABLEGEN_EXE mlir-tblgen)
-
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
+  include(TableGen)
+  include(AddLLVM)
+  include(AddMLIR)
 endif()
 
 function(torch_mlir_dialects_target_includes target)
@@ -54,6 +44,7 @@ function(torch_mlir_dialects_target_includes target)
   endif()
 endfunction()
 
+# TODO: Needed for tablegen. Remove.
 include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
 include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
 include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)

--- a/external/llvm-external-projects/torch-mlir-dialects/test/CMakeLists.txt
+++ b/external/llvm-external-projects/torch-mlir-dialects/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+# lit needs to find the tools, and the location differs for in-tree and out-of-tree builds.
+get_target_property(TORCH_MLIR_DIALECTS_TOOLS_DIR torch-mlir-dialects-opt RUNTIME_OUTPUT_DIRECTORY)
 configure_lit_site_cfg(
         ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
         ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/external/llvm-external-projects/torch-mlir-dialects/test/lit.cfg.py
+++ b/external/llvm-external-projects/torch-mlir-dialects/test/lit.cfg.py
@@ -60,7 +60,7 @@ config.standalone_tools_dir = os.path.join(config.torch_mlir_dialects_obj_root, 
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
-tool_dirs = [os.path.join(config.torch_mlir_obj_root, 'bin'), config.llvm_tools_dir]
+tool_dirs = [config.torch_mlir_dialects_tools_dir, config.llvm_tools_dir]
 tools = [
     "torch-mlir-dialects-opt",
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),

--- a/external/llvm-external-projects/torch-mlir-dialects/test/lit.cfg.py
+++ b/external/llvm-external-projects/torch-mlir-dialects/test/lit.cfg.py
@@ -60,9 +60,9 @@ config.standalone_tools_dir = os.path.join(config.torch_mlir_dialects_obj_root, 
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
-
-tool_dirs = [config.llvm_tools_dir]
+tool_dirs = [os.path.join(config.torch_mlir_obj_root, 'bin'), config.llvm_tools_dir]
 tools = [
+    "torch-mlir-dialects-opt",
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
 ]
 

--- a/external/llvm-external-projects/torch-mlir-dialects/test/lit.site.cfg.py.in
+++ b/external/llvm-external-projects/torch-mlir-dialects/test/lit.site.cfg.py.in
@@ -9,7 +9,7 @@
 import sys
 
 config.torch_mlir_dialects_obj_root = "@TORCH_MLIR_DIALECTS_BINARY_DIR@"
-config.torch_mlir_obj_root = "@TORCH_MLIR_BINARY_DIR@"
+config.torch_mlir_dialects_tools_dir = "@TORCH_MLIR_DIALECTS_TOOLS_DIR@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/external/llvm-external-projects/torch-mlir-dialects/test/lit.site.cfg.py.in
+++ b/external/llvm-external-projects/torch-mlir-dialects/test/lit.site.cfg.py.in
@@ -9,6 +9,7 @@
 import sys
 
 config.torch_mlir_dialects_obj_root = "@TORCH_MLIR_DIALECTS_BINARY_DIR@"
+config.torch_mlir_obj_root = "@TORCH_MLIR_BINARY_DIR@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/external/llvm-external-projects/torch-mlir-dialects/test/tmtensor/invalid.mlir
+++ b/external/llvm-external-projects/torch-mlir-dialects/test/tmtensor/invalid.mlir
@@ -67,7 +67,7 @@ func @scatter_mixed_tensor_memref(
 func @scatter_mixed_tensor_memref(
     %update : tensor<?x?xf32>, %indices : tensor<?x1xi32>,
     %original : tensor<?x?xf32>) -> memref<?x?xf32> {
-  // expected-error @+1 {{expected type of `outs` operand #0 'tensor<?x?xf32>' to be same as result type 'memref<?x?xf32>'}}
+  // expected-error @+1 {{op result #0 must be ranked tensor of any type values, but got 'memref<?x?xf32>'}}
   %0 = tm_tensor.scatter unique_indices(true)
       ins(%update, %indices : tensor<?x?xf32>, tensor<?x1xi32>)
       outs(%original : tensor<?x?xf32>) {

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -21,6 +21,10 @@ namespace Torch {
 int64_t toPositiveDim(int64_t dim, int64_t inputRank);
 bool isValidDim(int64_t dim, int64_t inputRank);
 bool getListConstructElements(Value v, SmallVectorImpl<Value> &elems);
+/// Returns the dimension indicated by `v` for a list of given `rank`.
+/// Negative values are adjusted with `toPositiveDim`. `None` is returned
+/// if the value fails `isValidDim`.
+llvm::Optional<int64_t> getMatchedListDim(Value v, int64_t rank);
 torch_upstream::ScalarType getScalarTypeForType(Type type);
 // Helper to convert a tensor to a specific scalar type.
 Value convertTensorToDtype(PatternRewriter &rewriter, Location loc, Value input,

--- a/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
+++ b/lib/Dialect/Torch/Transforms/SimplifyShapeCalculations.cpp
@@ -176,14 +176,13 @@ public:
       if (auto setItem = dyn_cast<Aten_SetItemTOp>(user)) {
         if (!setItem.use_empty())
           return failure();
-        int64_t index;
-        if (!matchPattern(setItem.idx(), m_TorchConstantInt(&index)))
-          return failure();
+        llvm::Optional<int64_t> indexOpt =
+            getMatchedListDim(setItem.idx(), runningList.size());
         // The index might be statically out of bounds.
-        if (index < 0 || index >= static_cast<int64_t>(runningList.size()))
+        if (!indexOpt)
           return failure();
         if (setItem.l() == op) {
-          runningList[index] = setItem.el();
+          runningList[*indexOpt] = setItem.el();
           generatedNewLiteral = true;
         }
         listLiterals.push_back(runningList);
@@ -199,7 +198,8 @@ public:
       return failure();
 
     // Rewrite all users to use the appropriate list literals.
-    Value latestLiteral = op;
+    Value latestLiteral = rewriter.create<PrimListConstructOp>(
+        op->getLoc(), op.getType(), op->getOperands());
     int nextLiteral = 0;
     for (Operation *user : usersToInterpret) {
       if (auto append = dyn_cast<AtenAppendTOp>(user)) {
@@ -292,15 +292,14 @@ static void refineShapeCalculateResult(ShapeCalculateOp op, int resultNum,
     // change the size of the list. It might clobber some elements, which then
     // become dimensions with unknown size.
     if (auto setItem = dyn_cast<Aten_SetItemTOp>(user)) {
-      int64_t index;
       // If the index is statically known, we can clobber only a single index.
       // Otherwise, we conservatively clobber all of them.
-      if (matchPattern(setItem.idx(), m_TorchConstantInt(&index)) &&
-          isValidDim(index, listConstruct->getNumOperands())) {
-        clobberedElements.set(index);
-      } else {
+      llvm::Optional<int64_t> indexOpt =
+          getMatchedListDim(setItem.idx(), listConstruct->getNumOperands());
+      if (indexOpt)
+        clobberedElements.set(*indexOpt);
+      else
         clobberedElements.set();
-      }
       continue;
     }
     // An unhandled op! We can't make any assumptions about the shape.

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -22,6 +22,16 @@ bool Torch::isValidDim(int64_t dim, int64_t inputRank) {
   return dim >= 0 && dim < inputRank;
 }
 
+llvm::Optional<int64_t> Torch::getMatchedListDim(Value v, int64_t rank) {
+  int64_t dim;
+  if (!matchPattern(v, m_TorchConstantInt(&dim)))
+    return llvm::None;
+  dim = toPositiveDim(dim, rank);
+  if (!isValidDim(dim, rank))
+    return llvm::None;
+  return dim;
+}
+
 bool Torch::getListConstructElements(Value v, SmallVectorImpl<Value> &elems) {
   auto listConstruct = v.getDefiningOp<PrimListConstructOp>();
   if (!listConstruct)

--- a/test/Dialect/Torch/invalid.mlir
+++ b/test/Dialect/Torch/invalid.mlir
@@ -138,7 +138,7 @@ builtin.func private @tensor.invalid_dtype() -> !torch.tensor<*,tuple<>>
 
 builtin.func @torch.tensor() {
   // Incompatible shape.
-  // expected-error@+1 {{incompatible}}
+  // expected-error@+1 {{must be Multi-dimensional array modeling Torch's Tensor type}}
   %0 = torch.tensor.literal(dense<42.0> : tensor<3x2xf32>) : !torch.vtensor<[],f32>
   return
 }
@@ -147,7 +147,7 @@ builtin.func @torch.tensor() {
 
 builtin.func @torch.tensor() {
   // Incompatible dtype.
-  // expected-error@+1 {{incompatible}}
+  // expected-error@+1 {{must be Multi-dimensional array modeling Torch's Tensor type}}
   %0 = torch.tensor.literal(dense<42.0> : tensor<f32>) : !torch.vtensor<[],f64>
   return
 }
@@ -156,7 +156,7 @@ builtin.func @torch.tensor() {
 
 builtin.func @torch.tensor() {
   // Incompatible type.
-  // expected-error@+1 {{incompatible}}
+  // expected-error@+1 {{must be Multi-dimensional array modeling Torch's Tensor type}}
   %0 = torch.tensor.literal(dense<42.0> : tensor<f32>) : i1
   return
 }


### PR DESCRIPTION
[Steve's PR](https://github.com/llvm/torch-mlir/pull/623) added `external/llvm-external-projects/torch-mlir-dialects` as a subdirectory. This PR follows up on this with changes so it builds correctly as a subdirectory of an out-of-tree build of `torch-mlir`.

This is not ready for upstreaming yet - there are things to clean up.