### PR TITLE
Clem.tmdialects upstreamable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 function(torch_mlir_target_includes target)
   set(_dirs
-    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${MLIR_GENERATED_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${TORCH_MLIR_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_BINARY_DIR}/include>
   )

--- a/e2e_testing/torchscript/xfail_sets.py
+++ b/e2e_testing/torchscript/xfail_sets.py
@@ -152,4 +152,6 @@ TOSA_PASS_SET = {
     "ViewNoChangeStaticModule_basic",
     "UnsafeViewExpandModule_basic",
     "ReshapeCollapseModule_basic",
+    "ElementwiseGeluModule_basic",
+    "GeluBackwardModule_basic",
 }

--- a/externals/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt
@@ -1,8 +1,11 @@
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-message(FATAL_ERROR
-  "This project is intended to be built as part of LLVM via "
-  "-DLLVM_EXTERNAL_PROJECTS=torch-mlir-dialects "
-  "-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
+  # The cmake configuration to build torch-mlir-dialects as
+  # an out-of-tree project has not been implemented. It can
+  # be built as part of LLVM or as a subdirectory of torch-mlir.
+  message(FATAL_ERROR
+    "This project is intended to be built as part of LLVM via "
+    "-DLLVM_EXTERNAL_PROJECTS=torch-mlir-dialects "
+    "-DLLVM_EXTERNAL_TORCH_MLIR_DIALECTS_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 option(MLIR_ENABLE_BINDINGS_PYTHON "Enables MLIR Python Bindings" OFF)
@@ -11,20 +14,32 @@ set(TORCH_MLIR_DIALECTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(TORCH_MLIR_DIALECTS_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 message(STATUS "Building torch-mlir-dialects project at ${TORCH_MLIR_DIALECTS_SOURCE_DIR} (into ${TORCH_MLIR_DIALECTS_BINARY_DIR})")
 
-# TODO: Fix this upstream so that global include directories are not needed.
-set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
-set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
-set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+if(MLIR_FOUND)
+  message(STATUS "LLVM and MLIR packages have already been configured.")
+else()
+  message(STATUS "torch-mlir-dialect is being built in-tree")
+  # An in-tree build, LLVM hasn't been installed yet.
+  # We compute these properties manually, they're otherwise
+  # contributed by find_package(MLIR...)
+  set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
+  set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
+  set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+  set(MLIR_INCLUDE_DIRS ${MLIR_INCLUDE_DIR} ${MLIR_GENERATED_INCLUDE_DIR})
+  set(LLVM_INCLUDE_DIRS ${LLVM_MAIN_INCLUDE_DIR})
 
-# TODO: Needed for tablegen. Remove.
-include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
-include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
-include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)
+  # Configure CMake and tablegen.
+  list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
+  list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+  set(MLIR_TABLEGEN_EXE mlir-tblgen)
+
+  include(TableGen)
+  include(AddLLVM)
+  include(AddMLIR)
+endif()
 
 function(torch_mlir_dialects_target_includes target)
   set(_dirs
-    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${MLIR_GENERATED_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_DIALECTS_BINARY_DIR}/include>
   )
@@ -39,14 +54,10 @@ function(torch_mlir_dialects_target_includes target)
   endif()
 endfunction()
 
-# Configure CMake and tablegen.
-list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
-list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
-set(MLIR_TABLEGEN_EXE mlir-tblgen)
-
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
+# TODO: Needed for tablegen. Remove.
+include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${TORCH_MLIR_DIALECTS_SOURCE_DIR}/include)
 
 add_subdirectory(include)
 add_subdirectory(lib)

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/CMakeLists.txt
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+# lit needs to find the tools, and the location differs for in-tree and out-of-tree builds.
+get_target_property(TORCH_MLIR_DIALECTS_TOOLS_DIR torch-mlir-dialects-opt RUNTIME_OUTPUT_DIRECTORY)
 configure_lit_site_cfg(
         ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
         ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/lit.cfg.py
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/lit.cfg.py
@@ -60,9 +60,9 @@ config.standalone_tools_dir = os.path.join(config.torch_mlir_dialects_obj_root, 
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
-
-tool_dirs = [config.llvm_tools_dir]
+tool_dirs = [config.torch_mlir_dialects_tools_dir, config.llvm_tools_dir]
 tools = [
+    "torch-mlir-dialects-opt",
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
 ]
 

--- a/externals/llvm-external-projects/torch-mlir-dialects/test/lit.site.cfg.py.in
+++ b/externals/llvm-external-projects/torch-mlir-dialects/test/lit.site.cfg.py.in
@@ -9,6 +9,7 @@
 import sys
 
 config.torch_mlir_dialects_obj_root = "@TORCH_MLIR_DIALECTS_BINARY_DIR@"
+config.torch_mlir_dialects_tools_dir = "@TORCH_MLIR_DIALECTS_TOOLS_DIR@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/include/torch-mlir/Dialect/Torch/Utils/Utils.h
+++ b/include/torch-mlir/Dialect/Torch/Utils/Utils.h
@@ -35,6 +35,9 @@ Value getDtypeIntValueForType(PatternRewriter &rewriter, Location loc,
 // Helper to convert a tensor to a specific scalar type.
 Value convertTensorToDtype(PatternRewriter &rewriter, Location loc, Value input,
                            Type dtype);
+// Helper funtion to get rank of `Base tensor type`.
+// -1 is returned if the tensorRank can't be determined.
+int getTensorRank(Value tensor);
 
 } // namespace Torch
 } // namespace torch

--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -2439,6 +2439,166 @@ LogicalResult ConvertAtenOp<AtenViewOp>::matchAndRewrite(
   return success();
 }
 
+static Value approximateErfOp(ConversionPatternRewriter &rewriter,
+                              Operation *op, Value x) {
+  // Using:
+  // https://en.wikipedia.org/wiki/Error_function#Numerical_approximations with
+  // maximum error as 5 x 10^-4 where a1 = 0.278393, a2 = 0.230389, a3 =
+  // 0.000972, a4 = 0.078108.
+  //
+  // Erf = 1 - 1 / (1 + a1X + a2X + a3X + a4X)^4
+
+  auto outType = x.getType().cast<TensorType>();
+  auto loc = op->getLoc();
+  auto absX = rewriter.create<tosa::AbsOp>(loc, outType, x);
+  auto zero = tosa::getConstTensor<float>(rewriter, op, 0, {}).getValue();
+  auto one = tosa::getConstTensor<float>(rewriter, op, 1, {}).getValue();
+
+  auto a1 = tosa::getConstTensor<float>(rewriter, op, 0.278393, {}).getValue();
+  auto a1X = rewriter.create<tosa::MulOp>(loc, outType, a1, absX, /*shift=*/0);
+  auto sum = rewriter.create<tosa::AddOp>(loc, outType, a1X, one);
+
+  auto a2 = tosa::getConstTensor<float>(rewriter, op, 0.230389, {}).getValue();
+  auto x2 = rewriter.create<tosa::MulOp>(loc, outType, absX, absX, /*shift=*/0);
+  auto a2X = rewriter.create<tosa::MulOp>(loc, outType, a2, x2, /*shift=*/0);
+  sum = rewriter.create<tosa::AddOp>(loc, outType, sum, a2X);
+
+  auto a3 = tosa::getConstTensor<float>(rewriter, op, 0.000972, {}).getValue();
+  auto x3 = rewriter.create<tosa::MulOp>(loc, outType, x2, absX, /*shift=*/0);
+  auto a3X = rewriter.create<tosa::MulOp>(loc, outType, a3, x3, /*shift=*/0);
+  sum = rewriter.create<tosa::AddOp>(loc, outType, sum, a3X);
+
+  auto a4 = tosa::getConstTensor<float>(rewriter, op, 0.078108, {}).getValue();
+  auto x4 = rewriter.create<tosa::MulOp>(loc, outType, x3, absX, /*shift=*/0);
+  auto a4X = rewriter.create<tosa::MulOp>(loc, outType, a4, x4, /*shift=*/0);
+  sum = rewriter.create<tosa::AddOp>(loc, outType, sum, a4X);
+
+  auto rcprl = rewriter.create<tosa::ReciprocalOp>(loc, outType, sum);
+  auto rcprl2 =
+      rewriter.create<tosa::MulOp>(loc, outType, rcprl, rcprl, /*shift=*/0);
+  auto rcprl4 =
+      rewriter.create<tosa::MulOp>(loc, outType, rcprl2, rcprl2, /*shift=*/0);
+  auto erf = rewriter.create<tosa::SubOp>(loc, outType, one, rcprl4);
+
+  // Deal with negative x.
+  auto cond = rewriter.create<tosa::GreaterEqualOp>(
+      loc,
+      RankedTensorType::get(outType.getShape(), rewriter.getIntegerType(1)), x,
+      zero);
+  auto negateErf = rewriter.create<tosa::NegateOp>(loc, outType, erf);
+
+  return rewriter.create<tosa::SelectOp>(loc, outType, cond, erf, negateErf);
+}
+
+static Value buildUnitNormalCdf(ConversionPatternRewriter &rewriter,
+                                Operation *op, Value x) {
+  auto zero = tosa::getConstTensor<float>(rewriter, op, 0, {}).getValue();
+  auto one = tosa::getConstTensor<float>(rewriter, op, 1, {}).getValue();
+  auto loc = op->getLoc();
+
+  // buildNormalCdf, mean = zero, sigma = one
+  auto outType = x.getType();
+  auto mean = zero;
+  Value xMinusMean = rewriter.create<tosa::SubOp>(loc, outType, x, mean);
+  // rsqrt of 2
+  Value rsqrt2 = tosa::getConstTensor<float>(rewriter, op, 0.70710678, {}).getValue();
+  Value erfArg = rewriter.create<tosa::MulOp>(loc, outType, xMinusMean, rsqrt2,
+                                              /*shift=*/0);
+  Value erf = approximateErfOp(rewriter, op, erfArg);
+  Value erfPlus1 = rewriter.create<tosa::AddOp>(loc, outType, one, erf);
+  Value oneHalf = tosa::getConstTensor<float>(rewriter, op, 0.5, {}).getValue();
+  Value normalCdf = rewriter.create<tosa::MulOp>(loc, outType, oneHalf,
+                                                 erfPlus1, /*shift=*/0);
+  return normalCdf;
+}
+
+// This lowering is based on Torch to LinAlg lowering.
+template <>
+LogicalResult ConvertAtenOp<AtenGeluOp>::matchAndRewrite(
+    AtenGeluOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+
+  // Not a tensor type.
+  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  if (!selfType)
+    return op.emitError("Only tensor types are currently supported");
+
+  auto selfElemTy = selfType.getElementType();
+  if (!selfElemTy.isa<mlir::FloatType>()) {
+    return op.emitError("Only floating-point datatype legalization supported");
+  }
+
+  // TODO: Handle approximate.
+  std::string approximate;
+  if (!matchPattern(op.approximate(), m_TorchConstantStr(approximate)) ||
+      approximate != "none") {
+    return op.emitError("Unsupported value of approximate");
+  }
+
+  Value cdf = buildUnitNormalCdf(rewriter, op, adaptor.self());
+  rewriter.replaceOpWithNewOp<tosa::MulOp>(
+      op, getTypeConverter()->convertType(op.getType()), adaptor.self(), cdf,
+      /*shift=*/0);
+
+  return success();
+}
+
+// This lowering is based on Torch to LinAlg lowering.
+template <>
+LogicalResult ConvertAtenOp<AtenGeluBackwardOp>::matchAndRewrite(
+    AtenGeluBackwardOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+
+  // Not a tensor type.
+  auto selfType = adaptor.self().getType().dyn_cast<TensorType>();
+  if (!selfType)
+    return op.emitError("Only tensor types are currently supported");
+
+  auto selfElemTy = selfType.getElementType();
+  if (!selfElemTy.isa<mlir::FloatType>()) {
+    return op.emitError("Only floating-point datatype legalization supported");
+  }
+
+  // TODO: Handle approximate.
+  std::string approximate;
+  if (!matchPattern(op.approximate(), m_TorchConstantStr(approximate)) ||
+      approximate != "none") {
+    return op.emitError("Unsupported value of approximate");
+  }
+
+  auto loc = op->getLoc();
+
+  const double cstAlpha0 = 1.12837916709551257390;
+  const double cstAlpha1 = 0.70710678118654752440;
+  const double oneHalf = 0.5;
+  const double kAlpha = cstAlpha0 * cstAlpha1;
+
+  Value kAlphaHalf =
+      tosa::getConstTensor<float>(rewriter, op, kAlpha * oneHalf, {})
+          .getValue();
+  Value negOneHalf =
+      tosa::getConstTensor<float>(rewriter, op, -0.5, {}).getValue();
+  Value inputSquared = rewriter.create<tosa::MulOp>(
+      loc, selfType, adaptor.self(), adaptor.self(), /*shift=*/0);
+  Value negHalfInputSquared = rewriter.create<tosa::MulOp>(
+      loc, selfType, inputSquared, negOneHalf, /*shift=*/0);
+  Value dinput =
+      rewriter.create<tosa::ExpOp>(loc, selfType, negHalfInputSquared);
+  Value cdf = buildUnitNormalCdf(rewriter, op, adaptor.self());
+  Value dinputInput = rewriter.create<tosa::MulOp>(loc, selfType, dinput,
+                                                   adaptor.self(), /*shift=*/0);
+  Value dinputInputAlpha = rewriter.create<tosa::MulOp>(
+      loc, selfType, dinputInput, kAlphaHalf, /*shift=*/0);
+  Value cdfExt =
+      rewriter.create<tosa::AddOp>(loc, selfType, dinputInputAlpha, cdf);
+  rewriter.replaceOpWithNewOp<tosa::MulOp>(
+      op, getTypeConverter()->convertType(op.getType()), adaptor.grad_output(),
+      cdfExt,
+      /*shift=*/0);
+
+  return success();
+}
+
 template <typename AtenOpT, typename TosaOpT>
 class ConvertAtenPoolingBaseOp : public OpConversionPattern<AtenOpT> {
 public:
@@ -2993,6 +3153,8 @@ public:
     INSERT_ATENOP_PATTERN(AtenContiguousOp);
     INSERT_ATENOP_PATTERN(AtenDropoutOp);
     INSERT_ATENOP_PATTERN(AtenViewOp);
+    INSERT_ATENOP_PATTERN(AtenGeluOp);
+    INSERT_ATENOP_PATTERN(AtenGeluBackwardOp);
 #undef INSERT_ATENOP_PATTERN
 
     if (failed(applyPartialConversion(getOperation(), target,

--- a/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
+++ b/lib/Dialect/Torch/Transforms/DecomposeComplexOps.cpp
@@ -21,19 +21,6 @@ using namespace mlir;
 using namespace mlir::torch;
 using namespace mlir::torch::Torch;
 
-// Helper funtion to get rank of `Base tensor type`.
-// -1 is returned if the tensorRank can't be determined.
-static int getTensorRank(Value tensor) {
-  int tensorRank = -1;
-  BaseTensorType tensorType = tensor.getType().cast<BaseTensorType>();
-
-  if (tensorType.hasSizes()) {
-    ArrayRef<int64_t> tensorShape = tensorType.getSizes();
-    tensorRank = tensorShape.size();
-  }
-  return tensorRank;
-}
-
 // Helper function to compute the return type of the reduction function.
 // `dim` specifies the dimension to reduce and `keepDim` preserves the rank of
 // the input tensor.

--- a/lib/Dialect/Torch/Utils/Utils.cpp
+++ b/lib/Dialect/Torch/Utils/Utils.cpp
@@ -95,3 +95,14 @@ Value Torch::convertTensorToDtype(PatternRewriter &rewriter, Location loc,
       loc, newType, input, convertIntVal, falseVal, falseVal, noneVal);
   return converted;
 }
+
+int Torch::getTensorRank(Value tensor) {
+  int tensorRank = -1;
+  BaseTensorType tensorType = tensor.getType().cast<BaseTensorType>();
+
+  if (tensorType.hasSizes()) {
+    ArrayRef<int64_t> tensorShape = tensorType.getSizes();
+    tensorRank = tensorShape.size();
+  }
+  return tensorRank;
+}

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/upstream_shape_helpers.py
@@ -318,7 +318,9 @@ def slice(self: List[int], dim: int, start: Optional[int], end: Optional[int], s
     end_val += self[dim]
   if start_val < 0:
     start_val = 0
-  elif start_val >= self[dim]:
+  # TODO: Remove this comment after https://github.com/pytorch/pytorch/pull/74980
+  # is merged to incorporate our local edit here.
+  elif start_val > self[dim]:
     start_val = self[dim]
   if end_val < start_val:
     end_val = start_val

--- a/python/torch_mlir_e2e_test/test_suite/index_put.py
+++ b/python/torch_mlir_e2e_test/test_suite/index_put.py
@@ -11,7 +11,7 @@ from torch_mlir_e2e_test.torchscript.annotations import annotate_args, export
 
 # ==============================================================================
 
-class IndexPutImplOneDimFloatNonAccumulateModule(torch.nn.Module):
+class IndexPutImpl1DFloatNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -29,13 +29,61 @@ class IndexPutImplOneDimFloatNonAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimFloatNonAccumulateModule())
-def IndexPutImplOneDimFloatNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DFloatNonAccumulateModule())
+def IndexPutImpl1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(100), torch.randint(100, (250,)),
                  tu.rand(250))
 
 
-class IndexPutImplOneDimIntNonAccumulateModule(torch.nn.Module):
+class IndexPutImpl2DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input, (index,), value,
+                                          accumulate=False,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl2DFloatNonAccumulateModule())
+def IndexPutImpl2DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
+                 tu.rand(5, 8))
+
+
+class IndexPutImpl3DFloatNonAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input, (index,), value,
+                                          accumulate=False,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl3DFloatNonAccumulateModule())
+def IndexPutImpl3DFloatNonAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
+                 tu.rand(5, 8, 6))
+
+
+class IndexPutImpl1DIntNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -53,13 +101,13 @@ class IndexPutImplOneDimIntNonAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimIntNonAccumulateModule())
-def IndexPutImplOneDimIntNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DIntNonAccumulateModule())
+def IndexPutImpl1DIntNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
                  torch.randint(10000, (300,)))
 
 
-class IndexPutImplOneDimFloatAccumulateModule(torch.nn.Module):
+class IndexPutImpl1DFloatAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -79,13 +127,61 @@ class IndexPutImplOneDimFloatAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimFloatAccumulateModule())
-def IndexPutImplOneDimFloatAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DFloatAccumulateModule())
+def IndexPutImpl1DFloatAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(1000), torch.randint(10, (500,)),
                  tu.rand(500))
 
 
-class IndexPutImplOneDimIntAccumulateModule(torch.nn.Module):
+class IndexPutImpl2DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
+                                          accumulate=True,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl2DFloatAccumulateModule())
+def IndexPutImpl2DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8), torch.randint(4, (5,)),
+                 tu.rand(5, 8))
+
+
+class IndexPutImpl3DFloatAccumulateModule(torch.nn.Module):
+
+  def __init__(self):
+    super().__init__()
+
+  @export
+  @annotate_args([
+      None,
+      ([-1, -1, -1], torch.float32, True),
+      ([-1], torch.int64, True),
+      ([-1, -1, -1], torch.float32, True),
+  ])
+  def forward(self, input, index, value):
+    return torch.ops.aten._index_put_impl_(input.clone(), (index,), value,
+                                          accumulate=True,
+                                          unsafe=False)
+
+
+@register_test_case(module_factory=lambda: IndexPutImpl3DFloatAccumulateModule())
+def IndexPutImpl3DFloatAccumulateModule_basic(module, tu: TestUtils):
+  module.forward(tu.rand(10, 8, 6), torch.randint(4, (5,)),
+                 tu.rand(5, 8, 6))
+
+
+class IndexPutImpl1DIntAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -105,14 +201,14 @@ class IndexPutImplOneDimIntAccumulateModule(torch.nn.Module):
                                           unsafe=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutImplOneDimIntAccumulateModule())
-def IndexPutImplOneDimIntAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPutImpl1DIntAccumulateModule())
+def IndexPutImpl1DIntAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
                  torch.randint(1000, (10,)))
 
 # ==============================================================================
 
-class IndexPutOneDimFloatNonAccumulateModule(torch.nn.Module):
+class IndexPut1DFloatNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -128,13 +224,13 @@ class IndexPutOneDimFloatNonAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimFloatNonAccumulateModule())
-def IndexPutOneDimFloatNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DFloatNonAccumulateModule())
+def IndexPut1DFloatNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(100), torch.randint(100, (250,)),
                  tu.rand(250))
 
 
-class IndexPutOneDimIntNonAccumulateModule(torch.nn.Module):
+class IndexPut1DIntNonAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -150,13 +246,13 @@ class IndexPutOneDimIntNonAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=False)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimIntNonAccumulateModule())
-def IndexPutOneDimIntNonAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DIntNonAccumulateModule())
+def IndexPut1DIntNonAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(1000, (200,)), torch.randint(100, (300,)),
                  torch.randint(10000, (300,)))
 
 
-class IndexPutOneDimFloatAccumulateModule(torch.nn.Module):
+class IndexPut1DFloatAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -172,13 +268,13 @@ class IndexPutOneDimFloatAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimFloatAccumulateModule())
-def IndexPutOneDimFloatAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DFloatAccumulateModule())
+def IndexPut1DFloatAccumulateModule_basic(module, tu: TestUtils):
   module.forward(tu.rand(1000), torch.randint(10, (500,)),
                  tu.rand(500))
 
 
-class IndexPutOneDimIntAccumulateModule(torch.nn.Module):
+class IndexPut1DIntAccumulateModule(torch.nn.Module):
 
   def __init__(self):
     super().__init__()
@@ -194,7 +290,7 @@ class IndexPutOneDimIntAccumulateModule(torch.nn.Module):
     return torch.ops.aten.index_put(input, (index,), value, accumulate=True)
 
 
-@register_test_case(module_factory=lambda: IndexPutOneDimIntAccumulateModule())
-def IndexPutOneDimIntAccumulateModule_basic(module, tu: TestUtils):
+@register_test_case(module_factory=lambda: IndexPut1DIntAccumulateModule())
+def IndexPut1DIntAccumulateModule_basic(module, tu: TestUtils):
   module.forward(torch.randint(100, (10,)), torch.randint(10, (10,)),
                  torch.randint(1000, (10,)))

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -375,16 +375,38 @@ func @torch.aten.gt.float$evaluate_to_false() -> !torch.bool {
 }
 
 
-// CHECK-LABEL:   func @torch.aten.ge.int$of_size.int(
-// CHECK-SAME:                                        %[[ARG:.*]]: !torch.tensor) -> !torch.bool {
-// CHECK:           %[[TRUE:.*]] = torch.constant.bool true
-// CHECK:           return %[[TRUE]] : !torch.bool
-func @torch.aten.ge.int$of_size.int(%arg0: !torch.tensor) -> !torch.bool {
+// CHECK-LABEL:   func @comparison_with_torch.aten.size.int(
+// CHECK-SAME:                                              %[[ARG0:.*]]: !torch.vtensor<[?,2],unk>) -> (!torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool) {
+// CHECK:           %[[SIZE:.*]] = torch.aten.size.int %[[ARG0]], %int0 : !torch.vtensor<[?,2],unk>, !torch.int -> !torch.int
+// CHECK:           %[[GE_0_LHS:.*]] = torch.aten.ge.int %int0, %[[SIZE]] : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[LT_0_LHS:.*]] = torch.aten.lt.int %int0, %[[SIZE]] : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[EQ_0_LHS:.*]] = torch.aten.eq.int %int0, %[[SIZE]] : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[NE_0_LHS:.*]] = torch.aten.ne.int %int0, %[[SIZE]] : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[GT_0_RHS:.*]] = torch.aten.gt.int %[[SIZE]], %int0 : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[LE_0_RHS:.*]] = torch.aten.le.int %[[SIZE]], %int0 : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[EQ_0_RHS:.*]] = torch.aten.eq.int %[[SIZE]], %int0 : !torch.int, !torch.int -> !torch.bool
+// CHECK:           %[[NE_0_RHS:.*]] = torch.aten.ne.int %[[SIZE]], %int0 : !torch.int, !torch.int -> !torch.bool
+// CHECK:           return %true, %true, %false, %false, %[[GE_0_LHS]], %[[LT_0_LHS]], %[[EQ_0_LHS]], %[[NE_0_LHS]], %[[GT_0_RHS]], %[[LE_0_RHS]], %[[EQ_0_RHS]], %[[NE_0_RHS]] : !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool
+func @comparison_with_torch.aten.size.int(%arg0: !torch.vtensor<[?,2],unk>) -> (!torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool) {
   %int0 = torch.constant.int 0
-  %0 = torch.aten.size.int %arg0, %int0 : !torch.tensor, !torch.int -> !torch.int
-  %1 = torch.aten.ge.int %0, %int0  : !torch.int, !torch.int -> !torch.bool
-  return %1 : !torch.bool
+  %0 = torch.aten.size.int %arg0, %int0 : !torch.vtensor<[?,2],unk>, !torch.int -> !torch.int
+  // Cases we can fold.
+  %1 = torch.aten.le.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+  %2 = torch.aten.ge.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+  %3 = torch.aten.lt.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+  %4 = torch.aten.gt.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+  // Cases we cannot fold.
+  %5 = torch.aten.ge.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+  %6 = torch.aten.lt.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+  %7 = torch.aten.eq.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+  %8 = torch.aten.ne.int %int0, %0 : !torch.int, !torch.int -> !torch.bool
+  %9 = torch.aten.gt.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+  %10 = torch.aten.le.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+  %11 = torch.aten.eq.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+  %12 = torch.aten.ne.int %0, %int0 : !torch.int, !torch.int -> !torch.bool
+  return %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12 : !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool, !torch.bool
 }
+
 
 // CHECK-LABEL:   func @torch.aten.eq.float$different_value() -> !torch.bool {
 // CHECK:           %[[FALSE:.*]] = torch.constant.bool false


### PR DESCRIPTION
This follows up on #623 for out-of-tree builds of torch-mlir, which added building `torch-mir-dialects` as a subdirectory.

We found that we needed some more `cmake` adaptions to make this work. We're initially opening this PR as a draft to gather opinions as to whether this approach suits at least the short-term `torch-mlir-dialects` goals.

Our goal is to support both in-tree and out-of-tree builds of `torch-mlir` with minimum hassle, for instance by using the same variable names in both setups. Specifically in `externals/llvm-external-projects/torch-mlir-dialects/CMakeLists.txt` :
- We use `MLIR_FOUND` to detect that it is being build as a subdirectory and the llvm+mlir cmake infrastructure is already set up (via find_package in the parent build) as opposed to an in-tree build.
- For in-tree,  the setting of variables and loading of llvm+mlir cmake infrastructure is now conditionally performed.
- For in-tree, the names of cmake variables being defined for are adjusted to match those `llvm-project` makes available through `find_package(MLIR REQUIRED CONFIG)`, under the assumption that those are the more "standardized" names.

Further optional items we could contribute if you're interested:
- build instructions for an out-of-tree setup (eg in README.md)
- a CI flow to test an out-of-tree setup, so that all code paths of the cmake scripts are tested (even though we expect most llvm developers to use in-tree builds)